### PR TITLE
Change maxlength for HOSTS to 254 (long hostnames)

### DIFF
--- a/src/main/java/tomekkup/helenos/dao/model/ClusterConfiguration.java
+++ b/src/main/java/tomekkup/helenos/dao/model/ClusterConfiguration.java
@@ -50,7 +50,7 @@ public class ClusterConfiguration extends AbstractEntity<Long> {
         return alias;
     }
 
-    @Column(name = "HOSTS", nullable = false, length=32)
+    @Column(name = "HOSTS", nullable = false, length=254)
     public String getHosts() {
         return hosts;
     }


### PR DESCRIPTION
the default of varchar(32) is too short for most dns hostnames, specially if you specify more than one host.
